### PR TITLE
Add support for compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ DCCD is a bash script that is meant to run via crontab. It checks the specified 
 
 You'll obviously need to have `git` and `docker compose` installed.
 
-Docker Compose files will need to be named `docker-compose.yml` or `docker-compose.yaml`.
+Docker Compose files will need to be named `docker-compose.yml`, `docker-compose.yaml`, `compose.yml` or `compose.yaml`.
 
 The script will redeploy all Docker Compose files if it finds the remote repo has changed (not just the individual files that have changed). Git is the source of truth.
 

--- a/dccd.sh
+++ b/dccd.sh
@@ -57,7 +57,7 @@ update_compose_files() {
             exit 1
         fi
 
-	find . -type f \( -name 'docker-compose.yml' -o -name 'docker-compose.yaml' \) | sort | while IFS= read -r file; do
+	find . -type f \( -name 'docker-compose.yml' -o -name 'docker-compose.yaml' -o -name 'compose.yaml' -o -name 'compose.yml' \) | sort | while IFS= read -r file; do
   	    # Extract the directory containing the file
   	    dir=$(dirname "$file")
 


### PR DESCRIPTION
Added because the [compose spec][1] prefers compose.yaml.

[1]: https://github.com/compose-spec/compose-spec/blob/master/spec.md#compose-file